### PR TITLE
Instance rename to server in TOS

### DIFF
--- a/content/about/tos.md
+++ b/content/about/tos.md
@@ -24,7 +24,7 @@ Definitions of various terms used throughout this document:
 | Term        | Definition                                                                                                                                   |
 |-------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Server      | Mastodon or other ActivityPub-protocol compatible software installed under a single domain which is configured to accept and relay posts between other systems. |
-| ActivtyPub  | Decentralized social networking protocol that enables different servers to communicate and share content with each other. |
+| ActivityPub | Decentralized social networking protocol that enables different servers to communicate and share content with each other. |
 | API         | Application programming interface, a way for two or more computer programs to communicate with each other. |
 | Federation  | Server to server communication, passing posts and other user data back and forth via an API. |
 | Database    | The system/location dedicated to storage of user data submitted through our website, via an API or from another client application. |

--- a/content/about/tos.md
+++ b/content/about/tos.md
@@ -4,13 +4,14 @@ title: Terms of Service
 
 # Terms of Service
 
-These terms describe how the Mastodon instance vmst.io collects, protects and uses the personally identifiable information you may provide through the vmst.io website or its API.
+These terms describe how the Mastodon server vmst.io collects, protects and uses the personally identifiable information you may provide through the vmst.io website or its API.
 The policy also describes the choices available to you regarding our use of your personal information and how you can access and update this information.
 
 This policy does not apply to the practices of companies that vmst.io does not own or control, or to individuals that vmst.io does not employ or manage.
 
 ## Changelog
 
+- [April 10, 2024](https://github.com/vmstio/docs/pull/5)
 - [October 18, 2023](https://github.com/vmstan/vmstio/pull/81)
 - [August 17, 2023](https://github.com/vmstan/vmstio/pull/71)
 - [July 25, 2023](https://github.com/vmstan/vmstio/commit/37cf880f12a23c2799bf9a8a735a90176e43b0c2#diff-ae85e39155eb0b9c9e8d944a2c038561b24c3c3b65d26c27d0c1aaa317f5ed5b)
@@ -22,9 +23,10 @@ Definitions of various terms used throughout this document:
 
 | Term        | Definition                                                                                                                                   |
 |-------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| Instance    | Mastodon or other ActivityPub-protocol compatible software installed under a single domain which is configured to accept and relay posts between other systems. |
+| Server      | Mastodon or other ActivityPub-protocol compatible software installed under a single domain which is configured to accept and relay posts between other systems. |
+| ActivtyPub  | Decentralized social networking protocol that enables different servers to communicate and share content with each other. |
 | API         | Application programming interface, a way for two or more computer programs to communicate with each other. |
-| Federation  | Instance to instance communication, passing posts and other user data back and forth via an API. |
+| Federation  | Server to server communication, passing posts and other user data back and forth via an API. |
 | Database    | The system/location dedicated to storage of user data submitted through our website, via an API or from another client application. |
 | Media Store | The system/location dedicated to storage of images, video, audio or other attachments submitted through our website, via an API or from another client application. |
 
@@ -32,7 +34,7 @@ Definitions of various terms used throughout this document:
 
 ### Basic account information
 
-- If you register on this instance, you will be asked to enter a username, an email address and a password.
+- If you register on this server, you will be asked to enter a username, an email address and a password.
 - You may also enter additional profile information such as a display name, biography, links, upload a profile picture and/or header image.
 - Your username, display name, biography, links, profile picture and header image are always listed publicly.
 
@@ -46,10 +48,10 @@ Definitions of various terms used throughout this document:
 ### Post visibility and delivery
 
 - When you submit a post, the date and time is stored as well as the application you submitted the post from. Posts may optionally contain media attachments, such as pictures and videos.
-- Your posts are delivered to your local followers, as well as other federated instances and copies are stored there. Due to circumstances outside out control we cannot guarantee that all federated instances will receive or process the your post.
-- When you delete posts, they are removed from the local database and a deletion request is sent to federated instances that may contain that data. Due to circumstances outside out control we cannot guarantee that all federated instances will receive or process the deletion.
-- All completed posts are stored and processed in the instance database.
-- There is no instance-side draft functionality nor does the instance save data from uncompleted posts to the database.
+- Your posts are delivered to your local followers, as well as other federated servers and copies are stored there. Due to circumstances outside out control we cannot guarantee that all federated servers will receive or process the your post.
+- When you delete posts, they are removed from the local database and a deletion request is sent to federated servers that may contain that data. Due to circumstances outside out control we cannot guarantee that all federated servers will receive or process the deletion.
+- All completed posts are stored and processed in the server database.
+- There is no server-side draft functionality nor does the server save data from uncompleted posts to the database.
 - Your browser or third-party client application may store uncompleted copies of posts in a cache or as a feature of the application, separately from our database and outside of these terms.
 
 #### Public and unlisted content
@@ -62,9 +64,9 @@ Definitions of various terms used throughout this document:
 #### Private mentions and followers-only posts
 
 - Followers-only posts are delivered to your followers and users who are mentioned in them, and Private mention posts are delivered only to users mentioned in them.
-- We make a good faith effort to limit the access to those posts only to authorized persons, but other instances may fail to do so.
+- We make a good faith effort to limit the access to those posts only to authorized persons, but other servers may fail to do so.
 
-Please keep in mind that it is technically possible for the operators of the instance and any receiving instance to view such messages, and that recipients may screenshot, copy or otherwise re-share them.
+Please keep in mind that it is technically possible for the operators of the server and any receiving server to view such messages, and that recipients may screenshot, copy or otherwise re-share them.
 
 ## IPs and Other Metadata
 
@@ -89,7 +91,7 @@ You should enable two-factor authentication to further secure access to your acc
 
 ### What is our data retention policy?
 
-We do not automatically delete data uploaded by our instance users on any regular basis, however you may individually [schedule regular deletions](https://vmst.io/statuses_cleanup) of your previous posts.
+We do not automatically delete data uploaded by our server users on any regular basis, however you may individually [schedule regular deletions](https://vmst.io/statuses_cleanup) of your previous posts.
 
 In order to minimize the growth of our database, we periodically purge remote user posts older than 90 days which has been received through federation (either directly or via relay) but have not been interacted with by a local user during that time.
 We also periodically purge media store data (images, videos, etc) from remote user posts that are older than 7 days, but this data may be retrieved on demand by our systems if requested again after this time period.
@@ -98,15 +100,15 @@ We also periodically purge media store data (images, videos, etc) from remote us
 
 You may irreversibly [delete your account](https://docs.joinmastodon.org/user/moving/#delete) and your data at anytime.
 
-When you delete your account, it is completely removed from the local database and a deletion request is sent to all federated instances that may be aware of your account.
+When you delete your account, it is completely removed from the local database and a deletion request is sent to all federated servers that may be aware of your account.
 
-- Due to the decentralized nature of Mastodon and other circumstances outside out control, we cannot guarantee that all federated instances will receive or process the deletion.
-- If you have concerns that another instance may still be holding your data after the completion of a deletion request, you will need to contact the administrators of that instance relevant to their policies.
+- Due to the decentralized nature of Mastodon and other circumstances outside out control, we cannot guarantee that all federated servers will receive or process the deletion.
+- If you have concerns that another server may still be holding your data after the completion of a deletion request, you will need to contact the administrators of that server relevant to their policies.
 
 We will make a good faith effort to automatically process all remote account deletion requests as they are received.
-In order to make sure we are not holding on to user accounts for remote users when it's no longer appropriate, we also periodically purge user data from remote instances where the account is no longer available or accessible, or for instances which we have chosen to no longer participate in federation.
+In order to make sure we are not holding on to user accounts for remote users when it's no longer appropriate, we also periodically purge user data from remote servers where the account is no longer available or accessible, or for servers which we have chosen to no longer participate in federation.
 
-If you are a member of a remote instance and would like your user data removed from our database or media stores, please contact one of our administrators.
+If you are a member of a remote server and would like your user data removed from our database or media stores, please contact one of our administrators.
 
 #### System backups
 
@@ -128,7 +130,7 @@ Such exports will include archive of your content, including:
 - Bookmarks you've made
 
 You may backup and export your data once every seven days, without then deleting or moving your account.
-To prevent abuse, followers cannot be exported without completing a user account migration to another Mastodon-compatible instance.
+To prevent abuse, followers cannot be exported without completing a user account migration to another Mastodon-compatible server.
 
 ### Do we use cookies?
 
@@ -144,8 +146,8 @@ We do not sell, trade, or otherwise transfer to outside parties your personally 
 This does not include trusted third parties who assist us in operating our site, conducting our business, or servicing you, so long as those parties agree to keep this information confidential.
 We may also release your information when we believe release is appropriate to comply with valid legal requests, enforce our site policies, or protect the rights, property, or safety of ourselves and others.
 
-Your public content may be downloaded by other instances in the network.
-Your public and followers-only posts are delivered to the instance where your followers reside, and private mentions are delivered to the instances of the recipients, in so far as those followers or recipients reside on a different instance than this.
+Your public content may be downloaded by other servers in the network.
+Your public and followers-only posts are delivered to the server where your followers reside, and private mentions are delivered to the servers of the recipients, in so far as those followers or recipients reside on a different server than this.
 
 When you authorize an application to use your account, depending on the scope of permissions you approve, it may access your public profile information, your following list, your followers, your lists, all your posts, and your favorites.
 
@@ -153,9 +155,9 @@ Applications can never access your email address or password.
 
 ## Moving Away
 
-You may close your Mastodon account or move it to another instance at any time.
-You may also [redirect users from your profile](https://docs.joinmastodon.org/user/moving/#migration) here to your identity on your new instance.
-You are in control of your identity and your social graph on Mastodon (and other federated instances), but the administrators here control your ability to use this instance and to interact with its users.
+You may close your Mastodon account or move it to another server at any time.
+You may also [redirect users from your profile](https://docs.joinmastodon.org/user/moving/#migration) here to your identity on your new server.
+You are in control of your identity and your social graph on Mastodon (and other federated servers), but the administrators here control your ability to use this server and to interact with its users.
 
 ## Usage by Children
 


### PR DESCRIPTION
- Changes the term "instance" to "server" for consistency with other areas of documentation.
- Adds definition for ActivityPub